### PR TITLE
Add batch runner API and AtCoder local runner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ runner-stop
 ログは`/tmp/atcoder-runner.log`です。APIの詳細は
 [docs/runner-api.md](docs/runner-api.md)を参照してください。
 
+## AtCoder Userscript
+
+[userscripts/atcoder-local-runner.user.js](userscripts/atcoder-local-runner.user.js)を
+TampermonkeyまたはViolentmonkeyへ追加してください。AtCoderの提出ボタンの横に`実行`と
+`実行して提出`、その下にサンプル結果とカスタムテストを追加します。`実行して提出`では
+全サンプルがACならそのまま提出します。runnerへは常に
+`profile=atcoder`を指定します。
+
+AtCoder Easy Test v2とはUIとキーボード操作が重複するため、置き換える場合はAtCoder Easy Test v2を
+無効化してください。
+
 ## Codeforces Userscript
 
 [userscripts/codeforces-local-runner.user.js](userscripts/codeforces-local-runner.user.js)を

--- a/docs/runner-api.md
+++ b/docs/runner-api.md
@@ -75,3 +75,20 @@ GET /health
 | `internalError` | runner内部エラー |
 
 サンプルのAC / WA判定はクライアント側でExpectedと`stdout`を比較して行います。
+
+## 複数入力の一括実行
+
+同じコードを一度だけコンパイルし、複数の標準入力に対して順番に実行します。
+
+```json
+{
+  "mode": "batch",
+  "profile": "atcoder",
+  "compilerName": "rust",
+  "sourceCode": "fn main() {}",
+  "stdins": ["1 2\n", "3 4\n"]
+}
+```
+
+レスポンスはコード実行レスポンスの配列です。コンパイルまたはrunner内部で失敗した場合は、
+エラーレスポンス1件のみを返します。

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -84,6 +84,15 @@ enum Request {
         source_code: String,
         stdin: String,
     },
+    Batch {
+        #[serde(default)]
+        profile: Option<Profile>,
+        #[serde(rename = "compilerName")]
+        compiler_name: String,
+        #[serde(rename = "sourceCode")]
+        source_code: String,
+        stdins: Vec<String>,
+    },
 }
 
 #[derive(Serialize)]
@@ -282,6 +291,24 @@ async fn handle(
             );
             Json(serde_json::to_value(response).unwrap())
         }
+        Request::Batch {
+            profile,
+            compiler_name,
+            source_code,
+            stdins,
+        } => {
+            let profile = profile.unwrap_or(state.default_profile);
+            let started = Instant::now();
+            let responses = run_many(&compiler_name, &source_code, &stdins, profile, &state).await;
+            eprintln!(
+                "[batch] profile={} compiler={} cases={} time={}ms",
+                profile.as_str(),
+                compiler_name,
+                responses.len(),
+                started.elapsed().as_millis(),
+            );
+            Json(serde_json::to_value(responses).unwrap())
+        }
     }
 }
 
@@ -292,8 +319,31 @@ async fn run(
     profile: Profile,
     state: &AppState,
 ) -> RunResponse {
+    run_many(
+        compiler_name,
+        source_code,
+        &[stdin.to_string()],
+        profile,
+        state,
+    )
+    .await
+    .into_iter()
+    .next()
+    .unwrap_or_else(|| internal_error(profile, "stdin is missing"))
+}
+
+async fn run_many(
+    compiler_name: &str,
+    source_code: &str,
+    stdins: &[String],
+    profile: Profile,
+    state: &AppState,
+) -> Vec<RunResponse> {
+    if stdins.is_empty() {
+        return Vec::new();
+    }
     match compiler_name {
-        "rust" => run_rust(source_code, stdin, profile, state).await,
+        "rust" => run_rust_many(source_code, stdins, profile, state).await,
         "python" | "pypy" => {
             let interpreter = if compiler_name == "python" {
                 "python3"
@@ -302,25 +352,30 @@ async fn run(
             };
             let dir = match tempdir() {
                 Ok(dir) => dir,
-                Err(error) => return internal_error(profile, format!("tempdir: {error}")),
+                Err(error) => {
+                    return vec![internal_error(profile, format!("tempdir: {error}"))];
+                }
             };
-            run_interpreted(interpreter, source_code, stdin, dir, profile).await
+            run_interpreted_many(interpreter, source_code, stdins, dir, profile).await
         }
-        other => internal_error(profile, format!("unknown compilerName: {other}")),
+        other => vec![internal_error(
+            profile,
+            format!("unknown compilerName: {other}"),
+        )],
     }
 }
 
-async fn run_rust(
+async fn run_rust_many(
     source_code: &str,
-    stdin: &str,
+    stdins: &[String],
     profile: Profile,
     state: &AppState,
-) -> RunResponse {
+) -> Vec<RunResponse> {
     let project = state.project(profile);
     let _guard = project.lock.lock().await;
 
     if let Err(error) = tokio::fs::write(project.path.join("src/main.rs"), source_code).await {
-        return internal_error(profile, format!("write source: {error}"));
+        return vec![internal_error(profile, format!("write source: {error}"))];
     }
 
     let mut command = Command::new(&project.cargo);
@@ -331,35 +386,37 @@ async fn run_rust(
         .kill_on_drop(true);
 
     match timeout(COMPILE_TIMEOUT, command.output()).await {
-        Err(_) => return compile_error(profile, "コンパイルがタイムアウトしました"),
+        Err(_) => return vec![compile_error(profile, "コンパイルがタイムアウトしました")],
         Ok(Err(error)) => {
-            return internal_error(profile, format!("cargo 起動失敗: {error}"));
+            return vec![internal_error(profile, format!("cargo 起動失敗: {error}"))];
         }
         Ok(Ok(output)) if !output.status.success() => {
-            return compile_error(profile, String::from_utf8_lossy(&output.stderr).trim());
+            return vec![compile_error(
+                profile,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            )];
         }
         Ok(Ok(_)) => {}
     }
 
-    execute(
-        &project.path.join("target/release/solution"),
-        &[],
-        stdin,
-        profile,
-    )
-    .await
+    let executable = project.path.join("target/release/solution");
+    let mut responses = Vec::with_capacity(stdins.len());
+    for stdin in stdins {
+        responses.push(execute(&executable, &[], stdin, profile).await);
+    }
+    responses
 }
 
-async fn run_interpreted(
+async fn run_interpreted_many(
     interpreter: &str,
     source_code: &str,
-    stdin: &str,
+    stdins: &[String],
     dir: tempfile::TempDir,
     profile: Profile,
-) -> RunResponse {
+) -> Vec<RunResponse> {
     let source = dir.path().join("solution.py");
     if let Err(error) = tokio::fs::write(&source, source_code).await {
-        return internal_error(profile, format!("write source: {error}"));
+        return vec![internal_error(profile, format!("write source: {error}"))];
     }
 
     let mut command = Command::new(interpreter);
@@ -367,23 +424,35 @@ async fn run_interpreted(
         .args(["-m", "py_compile", source.to_str().unwrap()])
         .kill_on_drop(true);
     match timeout(Duration::from_secs(10), command.output()).await {
-        Err(_) => return compile_error(profile, "構文チェックがタイムアウトしました"),
+        Err(_) => return vec![compile_error(profile, "構文チェックがタイムアウトしました")],
         Ok(Err(error)) => {
-            return internal_error(profile, format!("{interpreter} 起動失敗: {error}"));
+            return vec![internal_error(
+                profile,
+                format!("{interpreter} 起動失敗: {error}"),
+            )];
         }
         Ok(Ok(output)) if !output.status.success() => {
-            return compile_error(profile, String::from_utf8_lossy(&output.stderr).trim());
+            return vec![compile_error(
+                profile,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            )];
         }
         Ok(Ok(_)) => {}
     }
 
-    execute(
-        Path::new(interpreter),
-        &[source.to_str().unwrap()],
-        stdin,
-        profile,
-    )
-    .await
+    let mut responses = Vec::with_capacity(stdins.len());
+    for stdin in stdins {
+        responses.push(
+            execute(
+                Path::new(interpreter),
+                &[source.to_str().unwrap()],
+                stdin,
+                profile,
+            )
+            .await,
+        );
+    }
+    responses
 }
 
 async fn execute(command: &Path, args: &[&str], stdin_data: &str, profile: Profile) -> RunResponse {
@@ -559,5 +628,31 @@ mod tests {
         let value = "あ".repeat(MAX_OUTPUT);
         let truncated = truncate(value);
         assert!(truncated.ends_with("...(出力が長すぎるため切り捨て)"));
+    }
+
+    #[test]
+    fn batch_request_deserializes_multiple_inputs() {
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "mode": "batch",
+            "profile": "atcoder",
+            "compilerName": "rust",
+            "sourceCode": "fn main() {}",
+            "stdins": ["1\n", "2\n", "3\n"]
+        }))
+        .unwrap();
+
+        match request {
+            Request::Batch {
+                profile,
+                compiler_name,
+                stdins,
+                ..
+            } => {
+                assert_eq!(profile, Some(Profile::Atcoder));
+                assert_eq!(compiler_name, "rust");
+                assert_eq!(stdins, ["1\n", "2\n", "3\n"]);
+            }
+            Request::List | Request::Run { .. } => panic!("expected batch request"),
+        }
     }
 }

--- a/userscripts/atcoder-local-runner.user.js
+++ b/userscripts/atcoder-local-runner.user.js
@@ -1,0 +1,446 @@
+// ==UserScript==
+// @name         AtCoder Local Runner
+// @namespace    https://github.com/Twil3akine/AtCoder-Algo
+// @version      0.1.0
+// @description  AtCoderの問題ページで、現在のコードをローカル実行してサンプルを検証します。
+// @match        https://atcoder.jp/contests/*/tasks/*
+// @grant        unsafeWindow
+// @grant        GM_xmlhttpRequest
+// @connect      127.0.0.1
+// @run-at       document-idle
+// ==/UserScript==
+
+(function () {
+  "use strict";
+
+  const RUNNER_URL = "http://127.0.0.1:4000";
+  const PROFILE = "atcoder";
+  if (document.getElementById("ac-local-runner")) return;
+
+  const runOnlyButton = document.createElement("button");
+  runOnlyButton.type = "button";
+  runOnlyButton.id = "ac-lr-run-only";
+  runOnlyButton.className = "btn btn-default";
+  runOnlyButton.textContent = "実行";
+
+  const runSamplesButton = document.createElement("button");
+  runSamplesButton.type = "button";
+  runSamplesButton.id = "ac-lr-run-samples";
+  runSamplesButton.className = "btn btn-success";
+  runSamplesButton.textContent = "実行して提出";
+
+  const root = document.createElement("section");
+  root.id = "ac-local-runner";
+  root.innerHTML = `
+    <div class="ac-lr-header">
+      <span id="ac-lr-health" class="ac-lr-health pending">runnerを確認中...</span>
+    </div>
+    <div id="ac-lr-message" class="ac-lr-message" hidden></div>
+    <div id="ac-lr-sample-results" class="ac-lr-results"></div>
+    <details class="ac-lr-custom">
+      <summary>カスタムテスト</summary>
+      <label for="ac-lr-custom-input">標準入力</label>
+      <textarea id="ac-lr-custom-input" spellcheck="false"></textarea>
+      <button type="button" id="ac-lr-run-custom" class="btn btn-primary">実行</button>
+      <div id="ac-lr-custom-result" class="ac-lr-results"></div>
+    </details>
+  `;
+
+  installStyles();
+  const submitButton = document.querySelector("#submit");
+  const mount = submitButton?.closest(".form-group") || document.querySelector(".form-code-submit");
+  if (!mount || !submitButton) return;
+  submitButton.insertAdjacentElement("afterend", runOnlyButton);
+  runOnlyButton.insertAdjacentElement("afterend", runSamplesButton);
+  mount.insertAdjacentElement("afterend", root);
+
+  const healthLabel = root.querySelector("#ac-lr-health");
+  const message = root.querySelector("#ac-lr-message");
+  const sampleResults = root.querySelector("#ac-lr-sample-results");
+  const customInput = root.querySelector("#ac-lr-custom-input");
+  const customResult = root.querySelector("#ac-lr-custom-result");
+
+  runOnlyButton.addEventListener("click", () => runSamples(false));
+  runSamplesButton.addEventListener("click", () => runSamples(true));
+  root.querySelector("#ac-lr-run-custom").addEventListener("click", runCustomTest);
+
+  const samples = readSamples();
+  installSampleButtons(samples);
+  checkHealth();
+
+  async function checkHealth() {
+    healthLabel.className = "ac-lr-health pending";
+    healthLabel.textContent = "runnerを確認中...";
+    try {
+      const health = await requestJson("GET", "/health");
+      if (!Array.isArray(health.profiles) || !health.profiles.includes(PROFILE)) {
+        throw new Error("AtCoder profileがありません");
+      }
+      const version = health.versions?.rust?.atcoder;
+      healthLabel.className = "ac-lr-health ok";
+      healthLabel.textContent = version ? `接続済み (Rust ${version})` : "接続済み";
+      return true;
+    } catch (error) {
+      healthLabel.className = "ac-lr-health error";
+      healthLabel.textContent = "runner未接続";
+      showMessage(
+        `Local runnerへ接続できません。AtCoder-Algoディレクトリへ移動してrunnerを起動してください。\n${error.message}`,
+        "error",
+      );
+      return false;
+    }
+  }
+
+  async function runSamples(submitAfterAccepted) {
+    sampleResults.replaceChildren();
+    hideMessage();
+    if (samples.length === 0) {
+      showMessage("このページからサンプル入出力を取得できませんでした。", "error");
+      return;
+    }
+    if (!(await checkHealth())) return;
+
+    const language = selectedLanguage();
+    if (!language) return;
+    const sourceCode = getSourceCode();
+    if (!sourceCode.trim()) {
+      showMessage("ソースコードが空です。", "error");
+      return;
+    }
+
+    setBusy(true);
+    let allAccepted = true;
+    try {
+      const results = await runBatch(
+        language.compilerName,
+        sourceCode,
+        samples.map((sample) => sample.input),
+      );
+      for (let index = 0; index < samples.length; index += 1) {
+        const sample = samples[index];
+        const result = results[index] || results[0];
+        if (!result) throw new Error("runner returned no results");
+        const verdict = sampleVerdict(sample, result);
+        sampleResults.append(renderSampleResult(index + 1, sample, result, verdict));
+        if (verdict !== "AC") allAccepted = false;
+        if (result.status === "compileError" || result.status === "internalError") break;
+      }
+
+      if (allAccepted) {
+        if (submitAfterAccepted) submitCurrentCode();
+      }
+    } catch (error) {
+      showMessage(`実行リクエストに失敗しました。\n${error.message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runCustomTest() {
+    customResult.replaceChildren();
+    hideMessage();
+    if (!(await checkHealth())) return;
+
+    const language = selectedLanguage();
+    if (!language) return;
+    const sourceCode = getSourceCode();
+    if (!sourceCode.trim()) {
+      showMessage("ソースコードが空です。", "error");
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const result = await runSource(language.compilerName, sourceCode, customInput.value);
+      customResult.append(renderCustomResult(result));
+    } catch (error) {
+      showMessage(`実行リクエストに失敗しました。\n${error.message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runOneSample(sample, number, button) {
+    hideMessage();
+    if (!(await checkHealth())) return;
+    const language = selectedLanguage();
+    if (!language) return;
+    const sourceCode = getSourceCode();
+    if (!sourceCode.trim()) {
+      showMessage("ソースコードが空です。", "error");
+      return;
+    }
+
+    button.disabled = true;
+    try {
+      const result = await runSource(language.compilerName, sourceCode, sample.input);
+      const verdict = sampleVerdict(sample, result);
+      sampleResults.prepend(renderSampleResult(number, sample, result, verdict));
+    } catch (error) {
+      showMessage(`実行リクエストに失敗しました。\n${error.message}`, "error");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  function runSource(compilerName, sourceCode, stdin) {
+    return requestJson("POST", "/", {
+      mode: "run",
+      profile: PROFILE,
+      compilerName,
+      sourceCode,
+      stdin,
+    });
+  }
+
+  function runBatch(compilerName, sourceCode, stdins) {
+    return requestJson("POST", "/", {
+      mode: "batch",
+      profile: PROFILE,
+      compilerName,
+      sourceCode,
+      stdins,
+    });
+  }
+
+  function selectedLanguage() {
+    const select =
+      document.querySelector("#select-lang select.current") ||
+      document.querySelector('select[name="language_id"]');
+    const label = select?.selectedOptions?.[0]?.textContent?.trim() || "";
+    const value = select?.value || "";
+
+    if (/rust/i.test(label)) return { compilerName: "rust", label };
+    if (/pypy/i.test(label)) return { compilerName: "pypy", label };
+    if (/python/i.test(label)) return { compilerName: "python", label };
+
+    showMessage(
+      `選択中の言語にはlocal runnerが対応していません。Rust、CPython、PyPyを選択してください。\nLanguage ID: ${value || "不明"}`,
+      "error",
+    );
+    return null;
+  }
+
+  function getSourceCode() {
+    if (typeof unsafeWindow?.getSourceCode === "function") {
+      return String(unsafeWindow.getSourceCode());
+    }
+
+    const plain = document.querySelector("#plain-textarea, .plain-textarea");
+    if (typeof unsafeWindow?.ace !== "undefined" && document.querySelector("#editor")) {
+      const toggle = document.querySelector(".btn-toggle-editor");
+      if (!toggle?.classList.contains("active")) {
+        return unsafeWindow.ace.edit(document.querySelector("#editor")).getValue();
+      }
+    }
+    if (plain) return plain.value;
+
+    const textarea = document.querySelector('textarea[name="sourceCode"], textarea[name="source"]');
+    return textarea?.value || "";
+  }
+
+  function submitCurrentCode() {
+    const submit = document.querySelector("#submit");
+    if (!submit) {
+      showMessage("AtCoderの提出ボタンが見つかりませんでした。", "error");
+      return;
+    }
+    submit.click();
+  }
+
+  function readSamples() {
+    const selectors = [
+      ["#task-statement pre.source-code-for-copy", ".part"],
+      ["#task-statement .lang > *:first-child .div-btn-copy + pre", ".part"],
+      ["#task-statement .div-btn-copy + pre", ".part"],
+      ["#task-statement > .part section > pre", ".part"],
+      ["#task-statement > .part:not(.io-style) > h3 + section > pre", ".part"],
+      ["#task-statement pre", ".part"],
+    ];
+
+    for (const [selector, containerSelector] of selectors) {
+      const blocks = [...document.querySelectorAll(selector)].filter(
+        (pre) => !pre.closest(".io-style") && !pre.querySelector("var"),
+      );
+      if (blocks.length < 2 || blocks.length % 2 !== 0) continue;
+
+      const parsed = [];
+      for (let index = 0; index < blocks.length; index += 2) {
+        const input = blocks[index];
+        const output = blocks[index + 1];
+        const container = input.closest(containerSelector) || input.parentElement;
+        parsed.push({
+          input: readPre(input),
+          expected: readPre(output),
+          anchor: container?.querySelector(".btn-copy, .div-btn-copy, h1, h2, h3, h4, h5, h6"),
+        });
+      }
+      return parsed;
+    }
+    return [];
+  }
+
+  function installSampleButtons(testCases) {
+    testCases.forEach((sample, index) => {
+      if (!sample.anchor || sample.anchor.parentElement?.querySelector(".ac-lr-run-one")) return;
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "btn btn-default btn-xs ac-lr-run-one";
+      button.textContent = "Local Run";
+      button.addEventListener("click", () => runOneSample(sample, index + 1, button));
+      sample.anchor.insertAdjacentElement("afterend", button);
+    });
+  }
+
+  function readPre(pre) {
+    let value = "";
+    const visit = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) value += node.nodeValue;
+      else if (node.nodeName === "BR") value += "\n";
+      else node.childNodes.forEach(visit);
+    };
+    pre.childNodes.forEach(visit);
+    return value.replace(/\u00a0/g, " ").replace(/\r\n?/g, "\n");
+  }
+
+  function sampleVerdict(sample, result) {
+    if (result.status !== "ok") return statusVerdict(result.status);
+    return normalizeOutput(result.stdout || "") === normalizeOutput(sample.expected) ? "AC" : "WA";
+  }
+
+  function renderSampleResult(number, sample, result, verdict) {
+    const card = resultCard(`Sample ${number}`, verdict);
+    if (verdict === "WA") {
+      appendOutput(card, "Expected", sample.expected);
+      appendOutput(card, "Actual", result.stdout || "");
+    } else if (["CE", "RE", "ERROR"].includes(verdict)) {
+      appendOutput(card, "stderr", result.stderr || "(empty)");
+    }
+    return card;
+  }
+
+  function renderCustomResult(result) {
+    const verdict = result.status === "ok" ? "OK" : statusVerdict(result.status);
+    const card = resultCard("Custom Test", verdict);
+    appendOutput(card, "stdout", result.stdout || "(empty)");
+    appendOutput(card, "stderr", result.stderr || "(empty)");
+    return card;
+  }
+
+  function resultCard(title, verdict) {
+    const card = document.createElement("article");
+    card.className = "ac-lr-result-card";
+    const heading = document.createElement("div");
+    heading.className = "ac-lr-result-heading";
+    const name = document.createElement("strong");
+    name.textContent = title;
+    const badge = document.createElement("span");
+    badge.className = `ac-lr-verdict ${verdict.toLowerCase()}`;
+    badge.textContent = verdict;
+    heading.append(name, badge);
+    card.append(heading);
+    return card;
+  }
+
+  function appendOutput(card, title, value) {
+    const details = document.createElement("details");
+    details.open = true;
+    const summary = document.createElement("summary");
+    summary.textContent = title;
+    const pre = document.createElement("pre");
+    pre.textContent = value;
+    details.append(summary, pre);
+    card.append(details);
+  }
+
+  function statusVerdict(status) {
+    return {
+      ok: "AC",
+      compileError: "CE",
+      runtimeError: "RE",
+      timeLimitExceeded: "TLE",
+      internalError: "ERROR",
+    }[status] || "ERROR";
+  }
+
+  function normalizeOutput(value) {
+    return value
+      .replace(/\r\n?/g, "\n")
+      .split("\n")
+      .map((line) => line.replace(/[ \t]+$/g, ""))
+      .join("\n")
+      .replace(/\n+$/g, "");
+  }
+
+  function showMessage(text, type) {
+    message.hidden = false;
+    message.className = `ac-lr-message ${type}`;
+    message.textContent = text;
+  }
+
+  function hideMessage() {
+    message.hidden = true;
+  }
+
+  function setBusy(busy) {
+    runOnlyButton.disabled = busy;
+    runSamplesButton.disabled = busy;
+    for (const button of root.querySelectorAll("button")) button.disabled = busy;
+    for (const button of document.querySelectorAll(".ac-lr-run-one")) button.disabled = busy;
+  }
+
+  function requestJson(method, path, body) {
+    const url = `${RUNNER_URL}${path}`;
+    return new Promise((resolve, reject) => {
+      GM_xmlhttpRequest({
+        method,
+        url,
+        timeout: method === "GET" ? 3000 : 75000,
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        data: body ? JSON.stringify(body) : undefined,
+        onload(response) {
+          if (response.status < 200 || response.status >= 300) {
+            reject(new Error(`HTTP ${response.status}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(response.responseText));
+          } catch (error) {
+            reject(error);
+          }
+        },
+        onerror: () => reject(new Error("runner connection failed")),
+        ontimeout: () => reject(new Error("runner request timed out")),
+      });
+    });
+  }
+
+  function installStyles() {
+    const style = document.createElement("style");
+    style.textContent = `
+      #ac-local-runner { margin: 20px 0; padding: 15px; border: 1px solid #ccc; border-radius: 4px; background: #fff; }
+      .ac-lr-header, .ac-lr-result-heading { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+      .ac-lr-header { justify-content: space-between; margin-bottom: 12px; font-size: 16px; }
+      #ac-lr-run-only, #ac-lr-run-samples { margin-left: 5px; }
+      .ac-lr-health { border-radius: 999px; padding: 3px 8px; font-size: 12px; }
+      .ac-lr-health.ok { color: #176b2c; background: #dff4e4; }
+      .ac-lr-health.error { color: #9c1b1b; background: #fde2e2; }
+      .ac-lr-health.pending { color: #765b00; background: #fff2bd; }
+      .ac-lr-message { margin: 10px 0; padding: 9px; border-radius: 4px; white-space: pre-wrap; }
+      .ac-lr-message.error { color: #8d1717; background: #fde2e2; }
+      .ac-lr-message.ok { color: #176b2c; background: #dff4e4; }
+      .ac-lr-results { display: grid; gap: 8px; margin-top: 10px; }
+      .ac-lr-result-card { padding: 10px; border: 1px solid #ddd; border-radius: 4px; }
+      .ac-lr-result-heading { justify-content: space-between; }
+      .ac-lr-verdict { border-radius: 4px; padding: 3px 8px; font-weight: bold; }
+      .ac-lr-verdict.ac, .ac-lr-verdict.ok { color: #176b2c; background: #dff4e4; }
+      .ac-lr-verdict.wa, .ac-lr-verdict.ce, .ac-lr-verdict.re, .ac-lr-verdict.tle, .ac-lr-verdict.error { color: #9c1b1b; background: #fde2e2; }
+      .ac-lr-result-card pre { overflow: auto; max-height: 300px; padding: 8px; background: #f7f7f7; white-space: pre-wrap; }
+      .ac-lr-custom { margin-top: 12px; }
+      .ac-lr-custom > summary { cursor: pointer; font-weight: bold; margin-bottom: 8px; }
+      #ac-lr-custom-input { box-sizing: border-box; display: block; width: 100%; min-height: 110px; margin: 5px 0 8px; resize: vertical; font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .ac-lr-run-one { margin-left: 8px; vertical-align: middle; }
+    `;
+    document.head.append(style);
+  }
+})();


### PR DESCRIPTION
## 概要

- local runnerへ複数入力をまとめて実行するbatch APIを追加します
- AtCoder問題ページへ実行、サンプル実行、カスタムテスト、AC後の提出導線を追加します
- runner APIとAtCoder Userscriptの利用方法をドキュメントへ追記します

## 目的

サンプルごとの再コンパイルを避けつつ、AtCoderの問題ページからローカル検証と提出を一続きに行えるようにします。

## 影響

既存のCodeforces profileと単発run APIは維持されます。AtCoder Userscriptはrunnerへ `profile=atcoder` を明示します。

## 検証

- `cargo test --manifest-path runner/Cargo.toml`（4 tests passed）
